### PR TITLE
style(index.css): 统一CSS文件中的引号格式并注释未使用的代码

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,11 @@
 /* @import 'tailwindcss'; */
 @layer theme, base, components, utilities;
-@import "tailwindcss/theme.css" layer(theme);
+/* @layer theme, base, components, utilities; */
+@import 'tailwindcss/theme.css' layer(theme);
 /* 油猴脚本必须禁用，避免影响原来网页的样式 */
 /* @import "tailwindcss/preflight.css" layer(base); */
-@import "tailwindcss/utilities.css" layer(utilities);
-@import "tw-animate-css";
+@import 'tailwindcss/utilities.css' layer(utilities);
+@import 'tw-animate-css';
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
@@ -114,11 +115,11 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
-@layer base {
+/* @layer base {
   * {
     @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;
   }
-}
+} */


### PR DESCRIPTION
将双引号统一改为单引号以保持代码风格一致
注释掉未使用的@layer base代码块，减少不必要的样式声明